### PR TITLE
Lesson 27 - Adding Recipe Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ When first adding and testing db with real-time data, comment out `fetch event` 
 
 onSnapshot() is a method we can use on a Firebase collection to listen for any changes to that collection. This serves as a way for us to track db changes in real-time and then update the UI accordingly (keep UI and backend in sync). 
 
+add() method on Firestore collection requires an object. This object becomes a new document in db.
+
 ### **IndexedDB**
 While offline or not connected to a network, we can't reach Firebase to serve up data. We don't want to cache data like with our html and static assets because we could be constantly sending old/outdated information.
 
@@ -115,3 +117,5 @@ If we're offline and want to add data (or perform other CRUD actions), then that
 If we used a different db than Firebase Firestore, then we would need to access IndexedDB manually and communicate with IndexedDB directly. However, since we're using Firestore it already has tools built into the library that make it simple to interact with IndexedDB (e.g. store data from db into IndexedDB and sync up automatically with Firestore on re-connection).
 
 With data persistence enabled (see db.js) with IndexedDB, add back in caching in the `fetch event` with an added condition. Only cache assets as long as they are not data transactions with Firestore.
+
+onSnapshot() method not only listens for changes to Firebase db, but also for changes to IndexedDB. So, we can makes db changes offline and app will function the same as if there's still a connection to the network. 

--- a/js/db.js
+++ b/js/db.js
@@ -28,3 +28,25 @@ db.collection('recipes').onSnapshot(snapshot => {
     }
   }) 
 })
+
+// add new recipe
+// Query select <form> tag and set a 'submit' event listener on that form.
+const form = document.querySelector('form');
+form.addEventListener('submit', evt => {
+  // Prevent default action of refreshing the page
+  evt.preventDefault();
+
+  // Document to save to db
+  const recipe = {
+    title: form.title.value,
+    ingredients: form.ingredients.value
+  };
+
+  // Add document to db in specified collection
+  db.collection('recipes').add(recipe)
+    .catch(err => console.log(err))
+
+  // Reset form values to empty strings
+  form.title.value = '';
+  form.ingredients.value = '';
+});

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 const staticCacheName = 'site-static-v2'; // This is the name of the cache that we can see in the browser
-const dynamicCacheName = 'site-dynamic-v1';
+const dynamicCacheName = 'site-dynamic-v2';
 const assets = [
   '/',
   '/index.html',


### PR DESCRIPTION
Added functionality to db.js to add documents to 'recipes' collection in Firestore by setting listener on form tag and performing add() method on collection when form is submitted. To capture updated changes in db.js, changed dynamicCacheName to force update on cache. Updated README with notes regarding offline use of IndexedDB with app and how to add documents to Firestore.