### PR TITLE
Lesson 28 - Deleting Recipe Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ When first adding and testing db with real-time data, comment out `fetch event` 
 
 onSnapshot() is a method we can use on a Firebase collection to listen for any changes to that collection. This serves as a way for us to track db changes in real-time and then update the UI accordingly (keep UI and backend in sync). 
 
+doc() method on Firestore collection will find document with specified parameters. In this app, we use unique id to find the document.
+
 add() method on Firestore collection requires an object. This object becomes a new document in db.
+
+delete() method on Firestore collection will delete document(s) from the database.
 
 ### **IndexedDB**
 While offline or not connected to a network, we can't reach Firebase to serve up data. We don't want to cache data like with our html and static assets because we could be constantly sending old/outdated information.

--- a/index.html
+++ b/index.html
@@ -40,9 +40,7 @@
   </ul>  
 
   <!-- recipes -->
-  <div class="recipes container grey-text text-darken-1">
-    <h6 class="center">Ninja Recipes</h6>
-  </div>
+  <div class="recipes container grey-text text-darken-1"></div>
 
   <!-- add recipe btn -->
   <div class="center">

--- a/js/db.js
+++ b/js/db.js
@@ -18,13 +18,13 @@ db.enablePersistence()
 db.collection('recipes').onSnapshot(snapshot => {
   // console.log(snapshot.docChanges());  // Can see db changes in browser by using .docChanges() method on the snapshot object. This is returns an array of changes. [{type: "added", doc: pd, ...}, {type: "removed", doc: pd, ...}]
   snapshot.docChanges().forEach(change => {
-    // console.log(change, change.doc.data(), change.doc.id);
     if(change.type === "added") {
       // add the document data to the web page
-      renderRecipe(change.doc.data(), change.doc.id)
+      renderRecipe(change.doc.data(), change.doc.id)    // Function defined in ui.js
     }
     if(change.type === "removed") {
       // remove the document data from the web page
+      removeRecipe(change.doc.id);                      // Function defined in ui.js
     }
   }) 
 })
@@ -49,4 +49,17 @@ form.addEventListener('submit', evt => {
   // Reset form values to empty strings
   form.title.value = '';
   form.ingredients.value = '';
+});
+
+// delete recipe
+// Query select recipes class and add click event listener to items in <div> containing recipes class
+const recipeContainer = document.querySelector('.recipes');
+recipeContainer.addEventListener('click', evt => {
+  // If user selects trashcan icon, get the 'data-id' attribute of the icon from the DOM so that we can delete the correct recipe doc from db.
+  // Select the doc from recipes collection with matching id and delete doc from collection.
+  // This change is captured by onSnapshot() listener, so we can update the DOM accordingly.
+  if(evt.target.tagName === "I") {
+    const id = evt.target.getAttribute('data-id');
+    db.collection('recipes').doc(id).delete();
+  }
 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,3 +28,11 @@ const renderRecipe = (data, id) => {
   // Add recipes-html to the inner html of the recipes query selector
   recipes.innerHTML += html;
 };
+
+// Remove recipe from DOM
+const removeRecipe = (id) => {
+  // Set query selector to div containing 'recipe' class with the data-id attribute matching the id of the item we want to delete.
+  // Use remove() DOM method to delete recipe item.
+  const recipe = document.querySelector(`.recipe[data-id=${id}]`);
+  recipe.remove();
+};

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
-const staticCacheName = 'site-static-v2'; // This is the name of the cache that we can see in the browser
-const dynamicCacheName = 'site-dynamic-v2';
+const staticCacheName = 'site-static-v5'; // This is the name of the cache that we can see in the browser
+const dynamicCacheName = 'site-dynamic-v8';
 const assets = [
   '/',
   '/index.html',


### PR DESCRIPTION
Delete document by id functionality added to db.js. Uses click listener on icon target to get data-id and uses that id to select unique doc and delete it from db. This only removes doc from db, need to remove item from DOM as well. Added function to ui.js that is called in db.js at onSnapshot() method to remove 'recipe' class div from DOM with data-id attribute matching id passed in from onSnapshot() method where change type is 'removed'. Removed <h6> tag from index.html. Updated cache name versions to force changes in db.js and ui.js to reflect in caches. Updated README with notes on Firestore db methods used in project.